### PR TITLE
refactor(PLM-166): Make None check a keyword option

### DIFF
--- a/data_spec_validator/spec/defines.py
+++ b/data_spec_validator/spec/defines.py
@@ -160,17 +160,20 @@ class CheckerOP(Enum):
 
 
 class Checker:
-    def __init__(self, checks, optional=False, op=CheckerOP.ALL, extra=None):
+    def __init__(self, checks, optional=False, allow_none=False, op=CheckerOP.ALL, extra=None):
         """
         checks: list of str(Check)
         optional: boolean
                   Set optional to True, the validation process will be passed if the field is absent
+        allow_none: boolean
+                  Set allow_none to True, the field value can be None
         op: CheckerOP
         extra: None or Dict
         """
         self.checks = checks or []
         self._op = op
         self._optional = optional
+        self._allow_none = allow_none
         self.extra = extra or {}
 
         self._ensure()
@@ -178,6 +181,10 @@ class Checker:
     def _ensure(self):
         if self._optional and len(self.checks) == 0:
             raise ValueError('Require at least 1 check when set optional to True')
+
+    @property
+    def allow_none(self):
+        return self._allow_none
 
     @property
     def allow_optional(self):

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -91,6 +91,22 @@ class TestSpec(unittest.TestCase):
         nok_data = dict(none_field=3)
         assert is_something_error(TypeError, validate_data_spec, nok_data, _get_none_spec())
 
+    def test_allow_none(self):
+        def _get_allow_none_spec():
+            class AllowNoneSpec:
+                maybe_none_field = Checker([INT], allow_none=True)
+
+            return AllowNoneSpec
+
+        ok_data = dict(maybe_none_field=3)
+        assert validate_data_spec(ok_data, _get_allow_none_spec())
+
+        ok_data = dict(maybe_none_field=None)
+        assert validate_data_spec(ok_data, _get_allow_none_spec())
+
+        nok_data = dict(maybe_none_field='3')
+        assert is_something_error(TypeError, validate_data_spec, nok_data, _get_allow_none_spec())
+
     def test_bool(self):
         def _get_bool_spec():
             class BoolSpec:


### PR DESCRIPTION
[Why]
Sometime we might need multiple checks in a checker such as STR, LENGTH, NONE
And we use the op.ANY to validate the result if its either a string or None, but the results of STR and LENGHT must be combined togehter.
In this case, a list which passes the LENGTH check may lead to a wrong validation result.

[How]
Make None a keyword, so that we can satisfy more cases.

[PLM-166]

Why need this change ? / Root Cause :
--------------


Changed Made :
--------------


Test Scope / Change Impact :
--------------


[PLM-166]: https://hardcoretech.atlassian.net/browse/PLM-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ