### PR TITLE
Feat/spec object wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ validate_data_spec(ok_data, GreaterThanSpec) # raise Exception
 
 ### Spec Object Wrapper
 
-- Inherit Spec wrapper, the spec object can simply valdates data with a class method. (see [test_wrapped_spec_class_validate](https://github.com/travisliu/data-spec-validator/blob/feat/spec-object-wrapper/test/test_spec.py#L993) for more)
+- Inherit Spec wrapper, the spec object can simply validate data with a class method. (see [test_wrapped_spec_class_validate](https://github.com/travisliu/data-spec-validator/blob/feat/spec-object-wrapper/test/test_spec.py#L993) for more)
 ```python
 from data_spec_validator.spec import (
     INT,

--- a/README.md
+++ b/README.md
@@ -141,6 +141,22 @@ validate_data_spec(ok_data, GreaterThanSpec) # raise Exception
 "field: XXX not well-formatted"
 ```
 
+### Spec Object Wrapper
+
+- Inherit Spec wrapper, the spec object can simply valdates data with a class method. (see [test_wrapped_spec_class_validate](https://github.com/travisliu/data-spec-validator/blob/feat/spec-object-wrapper/test/test_spec.py#L993) for more)
+```python
+from data_spec_validator.spec import (
+    INT,
+    Spec,
+)
+
+class SomeSpec(Spec):
+    field_a = Checker([INT])
+
+some_data = dict(field_a=4)
+SomeSpec.validate(some_data) # return True
+```
+
 ## Test
 ```bash
 python -m unittest test.test_spec

--- a/data_spec_validator/spec/__init__.py
+++ b/data_spec_validator/spec/__init__.py
@@ -1,4 +1,5 @@
 from .actions import validate_data_spec
+from .wrappers import Spec
 
 # Export generic validator NAME
 from .defines import (

--- a/data_spec_validator/spec/validators.py
+++ b/data_spec_validator/spec/validators.py
@@ -45,6 +45,8 @@ def _raise_if_condition(condition, message, error_cls=RuntimeError):
 
 
 def _extract_fields(checker):
+    if hasattr(checker, 'spec_fields'): return checker.spec_fields.keys()
+
     return list(filter(lambda f: type(f) == str and not (f.startswith('__') and f.endswith('__')), dir(checker)))
 
 

--- a/data_spec_validator/spec/wrappers.py
+++ b/data_spec_validator/spec/wrappers.py
@@ -19,16 +19,18 @@ class SpecObject:
     pass
 
 class Spec:
-    __API_ATTRIBUTES = ["validate"]
     __spec_object = None
+
+    @classmethod
+    def __get_reserved_attributes(cls):
+        return dir(Spec)
 
     @classmethod
     def __create_specObject(cls):
         spec = SpecObject()
+        reserved_attributes = cls.__get_reserved_attributes()
         for attribute in dir(cls):
-            if attribute.startswith("__"): continue
-            if attribute.startswith("_Spec__"): continue
-            if attribute in cls.__API_ATTRIBUTES: continue
+            if attribute in reserved_attributes: continue
 
             setattr(spec, attribute, getattr(cls, attribute))
 

--- a/data_spec_validator/spec/wrappers.py
+++ b/data_spec_validator/spec/wrappers.py
@@ -1,5 +1,5 @@
 from .defines import BaseValidator
-
+from .actions import validate_data_spec
 
 class BaseWrapper:
     def __init__(self, wrapped_func):
@@ -14,3 +14,30 @@ class NotWrapper(BaseWrapper, BaseValidator):
         msg = ''.join(error.args)
         new_error = type(error)(f'not({msg})')
         return not ok, new_error
+
+class SpecObject:
+    pass
+
+class Spec:
+    __API_ATTRIBUTES = ["validate"]
+    __spec_object = None
+
+    @classmethod
+    def __create_specObject(cls):
+        spec = SpecObject()
+        for attribute in dir(cls):
+            if attribute.startswith("__"): continue
+            if attribute.startswith("_Spec__"): continue
+            if attribute in cls.__API_ATTRIBUTES: continue
+
+            setattr(spec, attribute, getattr(cls, attribute))
+
+        return spec
+
+    @classmethod
+    def validate(cls, data, **kwargs):
+        if (cls.__spec_object is None):
+            cls.__spec_object = cls.__create_specObject()
+
+        return validate_data_spec(data, cls.__spec_object, **kwargs)
+

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -1005,6 +1005,7 @@ class TestCustomSpec(unittest.TestCase):
 
         self.assertFalse(_get_wrapped_spec().validate(nok_data, nothrow=True))
 
+
 class TestMessageLevel(unittest.TestCase):
     def test_vague_message(self):
         def _get_int_spec():

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -29,6 +29,7 @@ from data_spec_validator.spec import (
     UUID,
     Checker,
     CheckerOP,
+    Spec,
     not_,
     reset_msg_level,
     validate_data_spec,
@@ -989,6 +990,20 @@ class TestCustomSpec(unittest.TestCase):
         nok_data = dict(key=10)
         assert is_something_error(ValueError, validate_data_spec, nok_data, _get_gt_10_spec())
 
+    def test_wrapped_spec_class_validate(self):
+        def _get_wrapped_spec():
+            class WrappedSpec(Spec):
+                int_field = Checker([INT])
+
+            return WrappedSpec
+
+        ok_data = dict(int_field=3)
+        assert _get_wrapped_spec().validate(ok_data)
+
+        nok_data = dict(int_field='3')
+        assert is_type_error(_get_wrapped_spec().validate, nok_data)
+
+        self.assertFalse(_get_wrapped_spec().validate(nok_data, nothrow=True))
 
 class TestMessageLevel(unittest.TestCase):
     def test_vague_message(self):


### PR DESCRIPTION
Why need this change ? / Root Cause :
--------------
The validate_data_spec method is great. But encapsulating spec object can makes that easier to use.

Changed Made :
--------------
This pull request only simply add an object wrapper into wrappers.py, and import it in __init__.py

- data_spec_validator/spec/wrappers.py
- data_spec_validator/spec/__init__.py

Test Scope / Change Impact :
--------------
There are only new wrappers added without any change of original codebase. So  no change Impact should be happened.

Any comment or suggestion is welcome