### PR TITLE
impl(GP-1095): raise the customized error when validate failure

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,14 @@
+name: test
+
+on:
+  - pull_request
+
+jobs:
+  audting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install the python packages and run test
+        run: |
+          pip install -r requirements-dev.txt
+          pytest -vv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,4 @@ black==22.3.0
 flake8==4.0.1
 twine==3.4.2
 parameterized==0.8.1
+pytest==7.1.2


### PR DESCRIPTION
Reason
--------------
both `@dsv` and `@dsv_request_meta` can raise the customized error when validate fail

1. provide an optional argument `throw_error` and it could be Exception or callable function
  1.1. override the original exception when validate fail, if provides the known exception.
  1.2. raise the exception via the function which pass the original exception


Changes
--------------
- extends the `@dsv` and `@dsv_request_meta` with extra argument `throw_error`
- introduce pytest as the GitHub Action CI backend

Test Scope
--------------
add test case for the throw_error

Checks
--------------
- [x] Unit tests are included or not applicable.
