### PR TITLE
feat: support dsv decorator in vanilla Django

### DIFF
--- a/data_spec_validator/decorator/decorators.py
+++ b/data_spec_validator/decorator/decorators.py
@@ -1,19 +1,50 @@
 from functools import wraps
 from typing import Dict, List, Union
 
+from data_spec_validator.spec import DSVError, raise_if, validate_data_spec
+
 try:
-    import rest_framework.exceptions as drf_exceptions
     from django.core.handlers.wsgi import WSGIRequest
-    from django.http import QueryDict
+    from django.http import HttpResponseBadRequest, HttpResponseForbidden, QueryDict
     from django.views.generic.base import View
-    from rest_framework.request import Request
 except ModuleNotFoundError as e:
     print(f'[DSV][WARNING] decorator: "dsv" cannot be used, {e}')
-from data_spec_validator.spec import DSVError, raise_if, validate_data_spec
+
+_enabled_drf = False
+try:
+    import rest_framework.exceptions as drf_exceptions
+    from rest_framework.request import Request
+
+    _enabled_drf = True
+except ModuleNotFoundError:
+    print('[DSV][INFO] decorator: using "dsv" without djangorestframework')
+
+
+class ValidationError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+
+class PermissionDenied(Exception):
+    def __init__(self, message):
+        self.message = message
+
+
+class ParseError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+
+def _is_wsgi_request(obj):
+    return isinstance(obj, WSGIRequest)
+
+
+def _is_drf_request(obj):
+    return _enabled_drf and isinstance(obj, Request)
 
 
 def _is_request(obj):
-    return isinstance(obj, WSGIRequest) or isinstance(obj, Request)
+    return _is_wsgi_request(obj) or _is_drf_request(obj)
 
 
 def _is_view(obj):
@@ -43,15 +74,15 @@ def _combine_named_params(data, **kwargs):
 
 def _extract_request_meta(req, **kwargs):
     raise_if(
-        not isinstance(req, WSGIRequest) and not isinstance(req, Request),
+        not _is_wsgi_request(req) and not _is_drf_request(req),
         RuntimeError(f'Unsupported req type, {type(req)}'),
     )
     return _combine_named_params(req.META, **kwargs)
 
 
 def _extract_request_param_data(req, **kwargs):
-    is_wsgi_request = isinstance(req, WSGIRequest)
-    is_request = isinstance(req, Request)
+    is_wsgi_request = _is_wsgi_request(req)
+    is_request = _is_drf_request(req)
     raise_if(
         not is_wsgi_request and not is_request,
         RuntimeError(f'Unsupported req type, {type(req)}'),
@@ -98,21 +129,42 @@ def _eval_is_multirow(multirow: bool, data: Union[Dict, List]) -> bool:
     return multirow or _is_data_type_list(data)
 
 
-def _do_validate(data, spec, multirow=False):
-    # Raise DRF's exception to let DRF's exception handler do something about it.
+def _do_validate(data, spec, multirow):
+    # Raise exceptions with message if validation failed.
     error = None
     try:
         is_multirow = _eval_is_multirow(multirow, data)
         validate_data_spec(data, spec, multirow=is_multirow)
     except ValueError as value_err:
-        error = drf_exceptions.ValidationError(str(value_err.args))
+        error = ValidationError(str(value_err.args))
     except PermissionError as perm_err:
-        error = drf_exceptions.PermissionDenied(str(perm_err.args))
+        error = PermissionDenied(str(perm_err.args))
     except (LookupError, TypeError, RuntimeError, DSVError) as parse_err:
-        error = drf_exceptions.ParseError(str(parse_err.args))
+        error = ParseError(str(parse_err.args))
 
     if error:
         raise error
+
+
+def _get_error_response(error, use_drf):
+    """
+    Return the error response based on the error type.
+    If the attribute use_drf is True, Raise DRF's exception to let DRF's exception handler do something about it.
+    """
+    if use_drf:
+        err_map = {
+            ValidationError: drf_exceptions.ValidationError,
+            PermissionDenied: drf_exceptions.PermissionDenied,
+            ParseError: drf_exceptions.ParseError,
+        }
+        raise err_map[error.__class__](error.message)
+
+    resp_map = {
+        ValidationError: HttpResponseBadRequest,
+        PermissionDenied: HttpResponseForbidden,
+        ParseError: HttpResponseBadRequest,
+    }
+    return resp_map[error.__class__](error.message)
 
 
 def dsv(spec, multirow=False):
@@ -129,7 +181,12 @@ def dsv(spec, multirow=False):
         def wrapped(*args, **kwargs):
             req = _extract_request(*args)
             data = _extract_request_param_data(req, **kwargs)
-            _do_validate(data, spec, multirow)
+
+            try:
+                _do_validate(data, spec, multirow)
+            except (ValidationError, PermissionDenied, ParseError) as err:
+                return _get_error_response(err, use_drf=_is_drf_request(req))
+
             return func(*args, **kwargs)
 
         return wrapped
@@ -143,7 +200,12 @@ def dsv_request_meta(spec):
         def wrapped(*args, **kwargs):
             req = _extract_request(*args)
             meta = _extract_request_meta(req, **kwargs)
-            _do_validate(meta, spec)
+
+            try:
+                _do_validate(meta, spec, multirow=False)
+            except (ValidationError, PermissionDenied, ParseError) as err:
+                return _get_error_response(err, use_drf=_is_drf_request(req))
+
             return func(*args, **kwargs)
 
         return wrapped


### PR DESCRIPTION
Reason
--------------
DRF is quite cumbersome for a simple project

Changes
--------------
1) avoid referencing DRF if it's not been installed
2) return HTTP response with status code that matches DRF's behavior if the request object is from vanilla Django views

Test Scope
--------------


Checks
--------------
- [x] Unit tests are included or not applicable.
