### PR TITLE
feat(PLM-2073): Support non-python naming convention query parameters…

### DIFF
--- a/data_spec_validator/spec/checks.py
+++ b/data_spec_validator/spec/checks.py
@@ -152,6 +152,7 @@ class Checker:
         optional: bool = False,
         allow_none: bool = False,
         op: CheckerOP = CheckerOP.ALL,
+        alias: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -161,12 +162,16 @@ class Checker:
         allow_none: boolean
                   Set allow_none to True, the field value can be None
         op: CheckerOP
+        alias: str or None
+               A string that represents the field name which will be used when extracting values from data payload
+        kwargs: dict
         """
         self.checks, class_check_type = self._sanitize_checks(raw_checks)
 
         self._op = op
         self._optional = optional
         self._allow_none = allow_none
+        self._alias = alias
 
         self._ensure(kwargs)
         self.extra = self._build_extra(class_check_type, kwargs)
@@ -251,3 +256,7 @@ class Checker:
     @property
     def is_op_all(self) -> bool:
         return self._op == CheckerOP.ALL
+
+    @property
+    def alias(self) -> str:
+        return self._alias

--- a/test/test_decorator_drf.py
+++ b/test/test_decorator_drf.py
@@ -92,12 +92,12 @@ class TestDSVDRF(unittest.TestCase):
     @parameterized.expand(['PUT', 'PATCH', 'DELETE'])
     def test_query_params_with_data(self, method):
         # arrange
-        qs = 'q_a=3&q_b=true'
-        payload = {'test_a': 'TEST A'}
+        qs = 'q_a=3&q_b=true&d.o.t=dot&array[]=a1&array[]=a2&array[]=a3'
+        payload = {'test_a': 'TEST A', 'test_f[]': [1, 2, 3]}
 
         fake_request = make_request(Request, method='POST', data=payload, qs=qs)
 
-        kwargs = {'test_b': 'TEST_B'}
+        kwargs = {'test_b': 'TEST_B', 'test_c.d.e': 'TEST C.D.E'}
 
         @dsv_feature(strict=True)
         class _ViewSpec:
@@ -105,15 +105,19 @@ class TestDSVDRF(unittest.TestCase):
             q_b = Checker([LIST_OF], LIST_OF=STR)
             test_a = Checker([ONE_OF], ONE_OF='TEST A')
             test_b = Checker([ONE_OF], ONE_OF='TEST_B')
+            test_c_d_e = Checker([ONE_OF], ONE_OF='TEST C.D.E', alias='test_c.d.e')
+            test_f_array = Checker([LIST_OF], LIST_OF=int, alias='test_f[]')
+            d_o_t = Checker([LIST_OF], LIST_OF=str, alias='d.o.t')
+            array = Checker([LIST_OF], LIST_OF=str, alias='array[]')
 
         class _View(View):
             @dsv(_ViewSpec)
             def decorated_func(self, req, *_args, **_kwargs):
-                pass
+                return True
 
         view = _View(request=fake_request)
         with override_method(view, fake_request, method) as request:
-            view.decorated_func(request, **kwargs)
+            assert view.decorated_func(request, **kwargs)
 
     def test_req_list_data_with_no_multirow_set(self):
         # arrange

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -1232,6 +1232,24 @@ class TestSpec(unittest.TestCase):
         assert is_something_error(LookupError, validate_data_spec, dict(d=1), _CondExistOtherFailAOBCSpec)
         # ==========================
 
+    def test_alias(self):
+        class AliasSpec:
+            dot_field = Checker([int], alias='dot.field')
+            array_field = Checker([LIST_OF], LIST_OF=str, alias='array_field[]')
+
+        ok_data = {
+            'dot.field': 3,
+            'array_field[]': ['a', 'b'],
+        }
+
+        assert validate_data_spec(ok_data, AliasSpec)
+
+        nok_data = {
+            'dot_field': 3,
+            'array_field': ['a', 'b'],
+        }
+        assert is_something_error(LookupError, validate_data_spec, nok_data, AliasSpec)
+
 
 class TestCustomSpec(unittest.TestCase):
     def test_incorrect_validator_class(self):

--- a/test/utils.py
+++ b/test/utils.py
@@ -19,7 +19,7 @@ def is_type_error(func, *args):
 
 def is_django_installed():
     try:
-        pass
+        import django  # noqa
     except ImportError:
         return False
     return True
@@ -27,7 +27,7 @@ def is_django_installed():
 
 def is_drf_installed():
     try:
-        pass
+        import rest_framework  # noqa
     except ImportError:
         return False
     return True
@@ -51,7 +51,7 @@ def make_request(cls, path='/', method='GET', user=None, headers=None, data=None
     if data:
         if method == 'GET':
             setattr(req, 'GET', data)
-        elif method == 'POST':
+        elif method in ['POST', 'PUT', 'PATCH', 'DELETE']:
             req.read()  # trigger RawPostDataException and force DRF to load data from req.POST
             req.META.update(
                 {


### PR DESCRIPTION
… for spec class field

[Why]
The http query parameter may come with special characters i.e. ., [, ], but it's not allowed to use it in class member name

[How]
1. Provide alias in Checker
2. Check spec feature and check checkers according to different field name
3. Add test cases

[PLM-2073]

Reason
--------------


Changes
--------------


Test Scope
--------------


Checks
--------------
- [x] Unit tests are included or not applicable.


[PLM-2073]: https://hardcoretech.atlassian.net/browse/PLM-2073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ