### PR TITLE
Upgrade pre-commit dependencies

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
           fetch-depth: 1024
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.6
+          python-version: 3.11
       - name: pre-commit
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha}}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,12 +2,12 @@ default_stages: [commit, push]
 fail_fast: false
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.1.1
     hooks:
       - id: autoflake
         args:
@@ -16,27 +16,27 @@ repos:
           - --remove-all-unused-imports
           - --ignore-init-module-imports # TODO: remove this
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 23.3.0
     hooks:
       - id: black
-        language_version: python3.6
+        language_version: python3.11
         args:
-          - --target-version=py36
+          - --target-version=py311
           - --line-length=120
           - --skip-string-normalization
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.5.1"
+    rev: v2.7.1
     hooks:
       - id: prettier
         additional_dependencies:
-        - prettier@2.2.1
+        - prettier@2.7.1
         exclude: node_modules
         types_or: [javascript, ts]
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8

--- a/data_spec_validator/decorator/decorators.py
+++ b/data_spec_validator/decorator/decorators.py
@@ -69,7 +69,6 @@ def _is_view(obj):
 
 def _combine_named_params(data, **kwargs):
     def combine_params(_data, params):
-
         raise_if(bool(set(_data.keys()) & set(params.keys())), RuntimeError('Data and URL named param have conflict'))
 
         if isinstance(_data, QueryDict):

--- a/data_spec_validator/spec/features.py
+++ b/data_spec_validator/spec/features.py
@@ -34,7 +34,6 @@ _FEAT_PARAMS = '__feat_params__'
 def _process_class(
     cls: Type, strict: bool, any_keys_set: Union[Set[Tuple[str, ...]], None], err_mode: ErrorMode
 ) -> Type:
-
     setattr(cls, _FEAT_PARAMS, _DSVFeatureParams(strict, any_keys_set, err_mode))
 
     return cls

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,11 @@
 [flake8]
 extend-ignore=
-    E203, # See https://github.com/PyCQA/pycodestyle/issues/373
-    E501, # style related, follow black
-    W503, # style related, follow black
+    # See https://github.com/PyCQA/pycodestyle/issues/373
+    E203,
+    # style related, follow black
+    E501,
+    # style related, follow black
+    W503,
 max-line-length = 120
 per-file-ignores =
     # imported but unused

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -1115,6 +1115,7 @@ class TestSpec(unittest.TestCase):
         dict(c=1)
         dict(d=1)
         """
+
         # ==========================
         class _CondExistOtherFailAOBOCOSpec:
             a = Checker([STR, COND_EXIST], optional=True, COND_EXIST=dict(WITHOUT=['c']))


### PR DESCRIPTION
Reason
--------------

The pre-commit cannot be installed with the later version of Python (3.11).

<details><summary>Details of the error message I've got with Python 3.11</summary>

```
[WARNING] Unstaged files detected.
[INFO] Stashing unstaged files to /Users/wangwei-hsiang/.cache/pre-commit/patch1685438267.
[INFO] Installing environment for https://github.com/pycqa/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Restored changes from /Users/wangwei-hsiang/.cache/pre-commit/patch1685438267.
An unexpected error has occurred: CalledProcessError: command: ('/Users/wangwei-hsiang/.cache/pre-commit/repoeb2qp9n1/py_env-python3/bin/python', '-mpip', 'install', '.')
return code: 1
expected return code: 0
stdout:
    Processing /Users/wangwei-hsiang/.cache/pre-commit/repoeb2qp9n1
      Installing build dependencies: started
      Installing build dependencies: finished with status 'done'
      Getting requirements to build wheel: started
      Getting requirements to build wheel: finished with status 'done'
      Preparing metadata (pyproject.toml): started
      Preparing metadata (pyproject.toml): finished with status 'error'
    
stderr:
      error: subprocess-exited-with-error
      
      × Preparing metadata (pyproject.toml) did not run successfully.
      │ exit code: 1
      ╰─> [17 lines of output]
          Traceback (most recent call last):
            File "/Users/wangwei-hsiang/.cache/pre-commit/repoeb2qp9n1/py_env-python3/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
              main()
            File "/Users/wangwei-hsiang/.cache/pre-commit/repoeb2qp9n1/py_env-python3/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
              json_out['return_val'] = hook(**hook_input['kwargs'])
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/Users/wangwei-hsiang/.cache/pre-commit/repoeb2qp9n1/py_env-python3/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 149, in prepare_metadata_for_build_wheel
              return hook(metadata_directory, config_settings)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/qz/tlkssfnj32320n9976w6qv4c0000gn/T/pip-build-env-9lukr_iu/overlay/lib/python3.11/site-packages/poetry/core/masonry/api.py", line 41, in prepare_metadata_for_build_wheel
              poetry = Factory().create_poetry(Path(".").resolve(), with_groups=False)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            File "/private/var/folders/qz/tlkssfnj32320n9976w6qv4c0000gn/T/pip-build-env-9lukr_iu/overlay/lib/python3.11/site-packages/poetry/core/factory.py", line 58, in create_poetry
              raise RuntimeError("The Poetry configuration is invalid:\n" + message)
          RuntimeError: The Poetry configuration is invalid:
            - [extras.pipfile_deprecated_finder.2] 'pip-shims<=0.3.4' does not match '^[a-zA-Z-_.0-9]+$'
          
          [end of output]
      
      note: This error originates from a subprocess, and is likely not a problem with pip.
    error: metadata-generation-failed
    
    × Encountered error while generating package metadata.
    ╰─> See above for output.
    
    note: This is an issue with the package mentioned above, not pip.
    hint: See above for details.
    
Check the log at /Users/wangwei-hsiang/.cache/pre-commit/pre-commit.log
```
</details> 

Changes
--------------

Though upgrading isort solely fixes the issue, it should be an excellent time to upgrade all the pre-commit dependencies. I've also tested it with Python 3.7 and passed.

Test Scope
--------------


Checks
--------------
- [x] Unit tests are included or not applicable.
