### PR TITLE
chore(validator): refine error msg for length validator without upper limit

### DIFF
--- a/data_spec_validator/spec/validators.py
+++ b/data_spec_validator/spec/validators.py
@@ -375,7 +375,7 @@ class LengthValidator(BaseValidator):
             info = '' if ok else ValueError(f'Length of {repr(value)} must be between {lower_bound} and {upper_bound}')
         else:
             ok = lower_bound <= len(value)
-            info = '' if ok else ValueError(f'Length of {repr(value)} must be greater than {lower_bound}')
+            info = '' if ok else ValueError(f'Length of {repr(value)} must be greater than or equal to {lower_bound}')
         return ok, info
 
 

--- a/data_spec_validator/spec/validators.py
+++ b/data_spec_validator/spec/validators.py
@@ -370,8 +370,12 @@ class LengthValidator(BaseValidator):
             RuntimeError('Lower boundary cannot less than 0 for length validator'),
         )
 
-        ok = lower_bound <= len(value) <= upper_bound if upper_bound else lower_bound <= len(value)
-        info = '' if ok else ValueError(f'Length of {repr(value)} must be between {lower_bound} and {upper_bound}')
+        if upper_bound:
+            ok = lower_bound <= len(value) <= upper_bound
+            info = '' if ok else ValueError(f'Length of {repr(value)} must be between {lower_bound} and {upper_bound}')
+        else:
+            ok = lower_bound <= len(value)
+            info = '' if ok else ValueError(f'Length of {repr(value)} must be greater than {lower_bound}')
         return ok, info
 
 

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -246,6 +246,24 @@ class TestSpec(unittest.TestCase):
         nok_data = dict(length_field='exceed')
         assert is_something_error(ValueError, validate_data_spec, nok_data, LengthSpec)
 
+        # assert error message
+        with self.assertRaises(ValueError) as e:
+            validate_data_spec(dict(length_field='ah'), LengthSpec)
+
+        expected_error_msg = "field: LengthSpec.length_field, reason: Length of 'ah' must be between 3 and 5"
+        self.assertEqual(str(e.exception), expected_error_msg)
+
+    def test_length__without_upper_limit(self):
+        class LengthSpec:
+            length_field = Checker([LENGTH], LENGTH=dict(min=3))
+
+        # assert error message
+        with self.assertRaises(ValueError) as e:
+            validate_data_spec(dict(length_field='ah'), LengthSpec)
+
+        expected_error_msg = "field: LengthSpec.length_field, reason: Length of 'ah' must be greater than 3"
+        self.assertEqual(str(e.exception), expected_error_msg)
+
     def test_decimal_place(self):
         class DecimalPlaceSpec:
             decimal_place_field = Checker([DECIMAL_PLACE], DECIMAL_PLACE=4)

--- a/test/test_spec.py
+++ b/test/test_spec.py
@@ -261,7 +261,7 @@ class TestSpec(unittest.TestCase):
         with self.assertRaises(ValueError) as e:
             validate_data_spec(dict(length_field='ah'), LengthSpec)
 
-        expected_error_msg = "field: LengthSpec.length_field, reason: Length of 'ah' must be greater than 3"
+        expected_error_msg = "field: LengthSpec.length_field, reason: Length of 'ah' must be greater than or equal to 3"
         self.assertEqual(str(e.exception), expected_error_msg)
 
     def test_decimal_place(self):


### PR DESCRIPTION
Reason
--------------
if the upper limit of the length validator is not given, the error message when violation would be `reason: Length of 'abc' must be between 5 and None`, which is bizarre.

Changes
--------------
make the error message in the format of `reason: Length of 'abc' must be greater than or equal to 5` if the upper limit is not given.

Test Scope
--------------


Checks
--------------
- [x] Unit tests are included or not applicable.
